### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,26 @@
+---
+name: Feature Request
+about: Suggest ideas and contribute in the growth of the project.
+title: "[Feature] <Subject-here>"
+labels: enhancement, triage
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+_A clear and concise description of what the problem is._
+
+## Describe the solution you'd like
+_A clear and concise description of what you want to happen._
+
+## Describe alternatives you've considered
+_A clear and concise description of any alternative solutions or features you've considered._
+
+## Additional context
+_Add any other context or screenshots about the feature request here._
+
+## Ownership of Contribution
+If the triage is approved,
+- [ ] I wish to submit the PR myself.
+- [ ] I wish to submit the PR. But if someone is willing to do it, go ahead.
+- [ ] I don't know how to fix this or make these changes. I wish others to pick this up for me.

--- a/.github/ISSUE_TEMPLATE/report-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-bug.md
@@ -1,0 +1,24 @@
+---
+name: Report Bug
+about: No project is perfect. Report the bug to move it a step towards perfection.
+title: "[Bug] <Subject-here>"
+labels: bug, triage
+assignees: ''
+
+---
+
+## Describe the Bug
+_A clear and concise description of what the bug is._
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. 
+
+## Additional Context
+_Add any other context about the problem here._
+
+## Ownership of Contribution
+If the triage is approved,
+- [ ] I wish to submit the PR myself.
+- [ ] I wish to submit the PR. But if someone is willing to do it, go ahead.
+- [ ] I don't know how to fix this or make these changes. I wish others to pick this up for me.


### PR DESCRIPTION
Add issue templates for the following
1. Report Bug
2. Feature Request

Additionally, the label `triage` is added by default along with respective tags (bug, enhancement).

Signed-off-by: Bhargav Ravuri <vaguecoder0to.n@gmail.com>